### PR TITLE
Fix typo in Codec.java

### DIFF
--- a/src/main/java/net/tridentsdk/server/netty/Codec.java
+++ b/src/main/java/net/tridentsdk/server/netty/Codec.java
@@ -41,7 +41,7 @@ import java.nio.charset.Charset;
  */
 @ThreadSafe
 public final class Codec {
-    //Current charset used by strings is UFT_8
+    //Current charset used by strings is UTF_8
     public static final Charset CHARSET = Charsets.UTF_8;
 
     private Codec() {} // Suppress initialization of utility class


### PR DESCRIPTION
As proposed in #1 this is still an issue - it may be small, however I believe it is important that the Trident project stays professional throughout it's development.
