### PR TITLE
fix NPE when a player tries to switch blocks when placing blocks

### DIFF
--- a/src/main/java/net/tridentsdk/server/packets/play/in/PacketPlayInBlockPlace.java
+++ b/src/main/java/net/tridentsdk/server/packets/play/in/PacketPlayInBlockPlace.java
@@ -18,6 +18,7 @@
 package net.tridentsdk.server.packets.play.in;
 
 import io.netty.buffer.ByteBuf;
+import net.tridentsdk.Trident;
 import net.tridentsdk.base.Block;
 import net.tridentsdk.base.Position;
 import net.tridentsdk.base.Substance;
@@ -94,6 +95,11 @@ public class PacketPlayInBlockPlace extends InPacket {
         TridentPlayer player = ((PlayerConnection) connection).player();
         location.setWorld(player.world());
 
+        if(player.heldItem() == null) {
+        	//TODO: add a check where this packet is called from if the heldItem() is not null
+        	return;
+        }
+        
         Substance substance = player.heldItem().type();
         Vector vector = determineOffset();
         if (!substance.isBlock()) {


### PR DESCRIPTION
Issue of the problem:

When a player scrolls through the item slots while he place blocks and the selection in the item slots is empty a NullPointerException appears.

Tempory solution:

I added a simple null check before the actually line which throws the NPE thats at line 102 in this pr request and I added a TODO in case the problem has a bigger impact than what I would expect.