### PR TITLE
fix NPE when a player tries to switch blocks when placing blocks

### DIFF
--- a/src/main/java/net/tridentsdk/server/packets/play/in/PacketPlayInBlockPlace.java
+++ b/src/main/java/net/tridentsdk/server/packets/play/in/PacketPlayInBlockPlace.java
@@ -94,6 +94,11 @@ public class PacketPlayInBlockPlace extends InPacket {
         TridentPlayer player = ((PlayerConnection) connection).player();
         location.setWorld(player.world());
 
+        if(player.heldItem() == null) {
+            //TODO: add a check where this is called from so it will not be null while a player interacts with the item slots containing air while placing blocks.
+            return;
+        }
+        
         Substance substance = player.heldItem().type();
         Vector vector = determineOffset();
         if (!substance.isBlock()) {


### PR DESCRIPTION
Issue of the problem:

When a player scrolls through the item slots while he place blocks and the selection in the item slots is empty a NullPointerException appears.

Tempory solution:

I added a simple null check before the actually line which throws the NPE thats at line 102 in this pr request and I added a TODO in case the problem has a bigger impact than what I would expect.

I made a older pr but due the merge conflict caused by myself I had to close it.
old pr: [50](https://github.com/tridentsdk/trident/pull/50)